### PR TITLE
Fix Sequence Ontology (so) URL

### DIFF
--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -826,6 +826,9 @@
         "snoRNABase"
       ]
     },
+    "so":  {
+      "download": "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.obo"
+    },
     "spd": {
       "pattern": "\\d{7}"
     },

--- a/src/pyobo/registries/obofoundry.json
+++ b/src/pyobo/registries/obofoundry.json
@@ -4059,7 +4059,7 @@
     "build": {
       "method": "obo2owl",
       "notes": "SWITCH",
-      "source_url": "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so.obo"
+      "source_url": "https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.obo"
     },
     "contact": {
       "email": "keilbeck@genetics.utah.edu",


### PR DESCRIPTION
I'm still in the process of downloading all the files, this URL had to be updated in the registry to resolve.