### PR TITLE
Fix typo in metaregistry

### DIFF
--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -419,7 +419,7 @@
       "pattern": "\\d{7}"
     },
     "interpro": {
-      "synoynms": [
+      "synonyms": [
         "InterPro",
         "IP"
       ],
@@ -609,7 +609,7 @@
       ]
     },
     "nextprot": {
-      "synoynms": [
+      "synonyms": [
         "NXP"
       ]
     },


### PR DESCRIPTION
Partially addresses #41, by fixing a typo in synonyms.