### PR TITLE
Add drugbank salt support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ pyobo.nomenclatures =
     conso            = pyobo.sources.conso:get_obo
     covid            = pyobo.sources.covid:get_obo
     drugbank         = pyobo.sources.drugbank:get_obo
+    drugbank.salt    = pyobo.sources.drugbank_salt:get_obo
     drugcentral      = pyobo.sources.drugcentral:get_obo
     eccode           = pyobo.sources.expasy:get_obo
     hgnc             = pyobo.sources.hgnc:get_obo

--- a/src/pyobo/__init__.py
+++ b/src/pyobo/__init__.py
@@ -3,9 +3,9 @@
 """A python package for handling and generating OBO."""
 
 from .extract import (  # noqa: F401
-    get_alts_to_id, get_ancestors, get_descendants, get_filtered_properties_mapping, get_filtered_xrefs, get_hierarchy,
-    get_id_name_mapping, get_id_synonyms_mapping, get_name, get_name_by_curie, get_name_id_mapping, get_primary_curie,
-    get_primary_identifier, get_subhierarchy, get_xrefs_df,
+    get_alts_to_id, get_ancestors, get_descendants, get_filtered_properties_mapping, get_filtered_relations_df,
+    get_filtered_xrefs, get_hierarchy, get_id_name_mapping, get_id_synonyms_mapping, get_name, get_name_by_curie,
+    get_name_id_mapping, get_primary_curie, get_primary_identifier, get_relations_df, get_subhierarchy, get_xrefs_df,
 )
 from .getters import get  # noqa: F401
 from .identifier_utils import normalize_curie, normalize_prefix  # noqa: F401

--- a/src/pyobo/extract.py
+++ b/src/pyobo/extract.py
@@ -225,8 +225,8 @@ def get_filtered_relations_df(
     **kwargs,
 ) -> pd.DataFrame:
     """Get all of the given relation."""
-    relation = get_reference_tuple(relation)
-    path = prefix_directory_join(prefix, 'cache', 'relations', f'{relation[0]}:{relation[1]}.tsv')
+    relation_prefix, relation_identifier = relation = get_reference_tuple(relation)
+    path = prefix_directory_join(prefix, 'cache', 'relations', f'{relation_prefix}:{relation_identifier}.tsv')
     all_relations_path = prefix_directory_join(prefix, 'cache', 'relations.tsv')
 
     # chebi_id        relation_ns     relation_id     target_ns       target_id
@@ -235,7 +235,7 @@ def get_filtered_relations_df(
     def _df_getter() -> pd.DataFrame:
         if os.path.exists(all_relations_path):
             df = pd.read_csv(all_relations_path, sep='\t')
-            idx = (df[RELATION_PREFIX] == relation[0]) & (df[RELATION_ID] == relation[1])
+            idx = (df[RELATION_PREFIX] == relation_prefix) & (df[RELATION_ID] == relation_identifier)
             columns = [f'{prefix}_id', TARGET_PREFIX, TARGET_ID]
             return df.loc[idx, columns]
 

--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -252,7 +252,8 @@
       "wikidata_property": "P715"
     },
     "drugbank.salt": {
-      "title": "DrugBank Salts"
+      "title": "DrugBank Salts",
+      "pattern": "DBSALT\\d{6}"
     },
     "drugcentral": {
       "synonyms": [

--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -102,7 +102,8 @@
       "synonyms": [
         "CASID",
         "SECONDARY_CAS_RN",
-        "CAS_RN"
+        "CAS_RN",
+        "cas_id"
       ],
       "wikidata_property": "P231"
     },

--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -252,8 +252,8 @@
       "wikidata_property": "P715"
     },
     "drugbank.salt": {
-      "title": "DrugBank Salts",
-      "pattern": "DBSALT\\d{6}"
+      "pattern": "DBSALT\\d{6}",
+      "title": "DrugBank Salts"
     },
     "drugcentral": {
       "synonyms": [

--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -251,6 +251,9 @@
       ],
       "wikidata_property": "P715"
     },
+    "drugbank.salt": {
+      "title": "DrugBank Salts"
+    },
     "drugcentral": {
       "synonyms": [
         "Drug_Central"
@@ -770,6 +773,9 @@
     },
     "oba": {
       "pattern": "\\d{7}"
+    },
+    "obo": {
+      "title": "Internal OBO and PyOBO Relations"
     },
     "ogms": {
       "not_available_as_obo": true

--- a/src/pyobo/sources/drugbank.py
+++ b/src/pyobo/sources/drugbank.py
@@ -184,7 +184,7 @@ def _extract_drug_info(drug_xml: ElementTree.Element) -> Mapping[str, Any]:
             {
                 'identifier': x.findtext(f'{ns}drugbank-id'),
                 'name': x.findtext(f'{ns}name'),
-                'unii': x.findtext(f'{ns}name'),
+                'unii': x.findtext(f'{ns}unii'),
                 'cas': x.findtext(f'{ns}cas-number'),
                 'inchikey': x.findtext(f'{ns}inchikey'),
             }

--- a/src/pyobo/sources/drugbank.py
+++ b/src/pyobo/sources/drugbank.py
@@ -9,17 +9,23 @@ import datetime
 import itertools as itt
 import logging
 import zipfile
+from functools import lru_cache
 from typing import Any, Iterable, Mapping
 from xml.etree import ElementTree
 
 from tqdm import tqdm
 
+from ..cache_utils import cached_pickle
 from ..path_utils import prefix_directory_join
-from ..struct import Obo, Reference, Synonym, Term
+from ..struct import Obo, Reference, Synonym, Term, TypeDef
 
 logger = logging.getLogger(__name__)
 
 PREFIX = 'drugbank'
+
+has_salt = TypeDef(
+    reference=Reference.default(identifier='has_salt', name='has salt'),
+)
 
 
 def get_obo() -> Obo:
@@ -29,6 +35,7 @@ def get_obo() -> Obo:
         name='DrugBank',
         iter_terms=iter_terms,
         auto_generated_by=f'bio2obo:{PREFIX}',
+        typedefs=[has_salt],
     )
 
 
@@ -38,11 +45,15 @@ def iter_terms() -> Iterable[Term]:
         yield _make_term(drug_info)
 
 
+@cached_pickle(prefix_directory_join(PREFIX, 'precompiled.pkl'))
 def iterate_drug_info() -> Iterable[Mapping[str, Any]]:
     """Iterate over DrugBank records."""
     root = get_xml_root()
-    for drug_xml in tqdm(root, desc='Drugs'):
-        yield _extract_drug_info(drug_xml)
+    rv = [
+        _extract_drug_info(drug_xml)
+        for drug_xml in tqdm(root, desc='Drugs')
+    ]
+    return rv
 
 
 DRUG_XREF_SKIP = {
@@ -90,7 +101,7 @@ def _make_term(drug_info: Mapping[str, Any]) -> Term:
         if identifier is not None:
             xrefs.append(Reference(prefix=k, identifier=identifier))
 
-    return Term(
+    term = Term(
         reference=Reference(prefix=PREFIX, identifier=drug_info['drugbank_id'], name=drug_info['name']),
         definition=drug_info['description'],
         xrefs=xrefs,
@@ -100,22 +111,30 @@ def _make_term(drug_info: Mapping[str, Any]) -> Term:
         ],
     )
 
+    for salt in drug_info.get('salts', []):
+        term.append_relationship(has_salt, Reference(
+            prefix='drugbank.salt',
+            identifier=salt['identifier'],
+            name=salt['name'],
+        ))
 
+    return term
+
+
+@lru_cache()
 def get_xml_root() -> ElementTree.Element:
     """Get the DrugBank XML parser root.
 
     Takes between 35-60 seconds.
-
-    :param path: A custom URL for DrugBank XML file
     """
     # FIXME get data automatically
     path = prefix_directory_join(PREFIX, 'drugbank_all_full_database.xml.zip')
 
     with zipfile.ZipFile(path) as zip_file:
         with zip_file.open('full database.xml') as file:
-            logger.info('loading XML')
+            logger.info('loading DrugBank XML')
             tree = ElementTree.parse(file)
-            logger.info('done parsing XML')
+            logger.info('done parsing DrugBank XML')
 
     return tree.getroot()
 
@@ -160,6 +179,16 @@ def _extract_drug_info(drug_xml: ElementTree.Element) -> Mapping[str, Any]:
 
             }
             for x in drug_xml.findall(f"{ns}patents/{ns}patent")
+        ],
+        'salts': [
+            {
+                'identifier': x.findtext(f'{ns}drugbank-id'),
+                'name': x.findtext(f'{ns}name'),
+                'unii': x.findtext(f'{ns}name'),
+                'cas': x.findtext(f'{ns}cas-number'),
+                'inchikey': x.findtext(f'{ns}inchikey'),
+            }
+            for x in drug_xml.findall(f'{ns}salts/{ns}salt')
         ],
         'xrefs': [
             {

--- a/src/pyobo/sources/drugbank_salt.py
+++ b/src/pyobo/sources/drugbank_salt.py
@@ -3,6 +3,14 @@
 """Convert DrugBank Salts to OBO.
 
 Run with ``python -m pyobo.sources.drugbank_salt``
+
+Get relations between drugbank salts and drugbank parents with
+``pyobo relations drugbank --relation obo:has_salt`` or
+
+.. code-block:: python
+
+    import pyobo
+    df = pyobo.get_filtered_relations_df('drugbank', 'obo:has_salt')
 """
 
 import logging

--- a/src/pyobo/sources/drugbank_salt.py
+++ b/src/pyobo/sources/drugbank_salt.py
@@ -33,7 +33,7 @@ def iter_terms() -> Iterable[Term]:
             xrefs = []
             for key in ['unii', 'cas', 'inchikey']:
                 identifier = salt.get(key)
-                if identifier is not None:
+                if identifier:
                     xrefs.append(Reference(prefix=key, identifier=identifier))
 
             yield Term(

--- a/src/pyobo/sources/drugbank_salt.py
+++ b/src/pyobo/sources/drugbank_salt.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+"""Convert DrugBank Salts to OBO.
+
+Run with ``python -m pyobo.sources.drugbank_salt``
+"""
+
+import logging
+from typing import Iterable
+
+from .drugbank import iterate_drug_info
+from ..struct import Obo, Reference, Term
+
+logger = logging.getLogger(__name__)
+
+PREFIX = 'drugbank.salt'
+
+
+def get_obo() -> Obo:
+    """Get DrugBank Salts as OBO."""
+    return Obo(
+        ontology=PREFIX,
+        name='DrugBank Salts',
+        iter_terms=iter_terms,
+        auto_generated_by=f'bio2obo:{PREFIX}',
+    )
+
+
+def iter_terms() -> Iterable[Term]:
+    """Iterate over DrugBank Salt terms in OBO."""
+    for drug_info in iterate_drug_info():
+        for salt in drug_info.get('salts', []):
+            xrefs = []
+            for key in ['unii', 'cas_id', 'inchikey']:
+                identifier = salt.get(key)
+                if identifier is not None:
+                    xrefs.append(Reference(prefix=key, identifier=identifier))
+
+            yield Term(
+                reference=Reference(
+                    prefix=PREFIX,
+                    identifier=salt['identifier'],
+                    name=salt['name'],
+                ),
+                xrefs=xrefs,
+            )
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    get_obo().write_default()

--- a/src/pyobo/sources/drugbank_salt.py
+++ b/src/pyobo/sources/drugbank_salt.py
@@ -31,7 +31,7 @@ def iter_terms() -> Iterable[Term]:
     for drug_info in iterate_drug_info():
         for salt in drug_info.get('salts', []):
             xrefs = []
-            for key in ['unii', 'cas_id', 'inchikey']:
+            for key in ['unii', 'cas', 'inchikey']:
                 identifier = salt.get(key)
                 if identifier is not None:
                     xrefs.append(Reference(prefix=key, identifier=identifier))

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -5,7 +5,7 @@
 from dataclasses import dataclass, field
 from typing import Iterable, List, Mapping, Optional, Tuple, Union
 
-from .reference import Reference, Referenced
+from .reference import Reference, Referenced, normalize_curie
 
 __all__ = [
     'TypeDef',
@@ -70,6 +70,11 @@ def get_reference_tuple(relation: Union[Tuple[str, str], Reference, TypeDef]) ->
         return relation.prefix, relation.identifier
     elif isinstance(relation, tuple):
         return relation
+    elif isinstance(relation, str):
+        prefix, identifier = normalize_curie(relation)
+        if prefix is None:
+            raise ValueError(f'string given is not valid curie: {relation}')
+        return prefix, identifier
     else:
         raise TypeError(f'Relation is invalid tyoe: {relation}')
 


### PR DESCRIPTION
Closes #80

This PR does the following:

- adds `drugbank.salt` to the metaregistry
- adds a nomenclature for `drugbank.salt`
- adds the `obo:has_salt` relation between `drugbank` and `drugbank.salt` curies that goes into the DrugBank OBO

Ultimately, to get the drugbank to salt mapping, use:

```python
import pyobo
df = pyobo.get_filtered_relations_df('drugbank', 'obo:has_salt')
```

This has 3 columns - drugbank ID, target namespace prefix (always drugbank.salt), and target namespace prefix.