### PR TITLE
Update Gilda code

### DIFF
--- a/src/pyobo/apps/gilda/app.py
+++ b/src/pyobo/apps/gilda/app.py
@@ -2,7 +2,7 @@
 
 """PyOBO's Gilda Service."""
 
-from typing import Iterable, Optional, Union
+from typing import Iterable, Union
 
 import flask
 from flask_bootstrap import Bootstrap

--- a/src/pyobo/apps/gilda/app.py
+++ b/src/pyobo/apps/gilda/app.py
@@ -2,21 +2,15 @@
 
 """PyOBO's Gilda Service."""
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 import flask
-import gilda.term
 from flask_bootstrap import Bootstrap
 from flask_wtf import FlaskForm
-from gilda.generate_terms import filter_out_duplicates
-from gilda.grounder import Grounder
-from gilda.process import normalize
-from tqdm import tqdm
 from wtforms.fields import StringField, SubmitField
 from wtforms.validators import DataRequired
 
-from pyobo import get_id_name_mapping, get_id_synonyms_mapping
-from pyobo.utils.io import multidict
+from pyobo.gilda_utils import get_grounder
 
 
 class Form(FlaskForm):
@@ -30,9 +24,9 @@ class Form(FlaskForm):
         return flask.redirect(flask.url_for("ground", text=self.text.data))
 
 
-def get_app(prefix: str, url: Optional[str] = None):
+def get_app(prefix: Union[str, Iterable[str]]):
     """Make an app for grounding the text."""
-    grounder = get_grounder(prefix, url=url)
+    grounder = get_grounder(prefix)
 
     app = flask.Flask(__name__)
     app.config["WTF_CSRF_ENABLED"] = False
@@ -52,40 +46,3 @@ def get_app(prefix: str, url: Optional[str] = None):
         return flask.jsonify([scored_match.to_json() for scored_match in grounder.ground(text)])
 
     return app
-
-
-def get_grounder(prefix, url: Optional[str] = None) -> Grounder:
-    """Get a Gilda grounder for the given namespace."""
-    terms = list(get_gilda_terms(prefix, url=url))
-    terms = filter_out_duplicates(terms)
-    terms = multidict((term.norm_text, term) for term in terms)
-    return Grounder(terms)
-
-
-def get_gilda_terms(prefix: str, url: Optional[str] = None) -> Iterable[gilda.term.Term]:
-    """Get gilda terms for the given namespace."""
-    id_to_name = get_id_name_mapping(prefix, url=url)
-    for identifier, name in tqdm(id_to_name.items(), desc="mapping names"):
-        yield gilda.term.Term(
-            norm_text=normalize(name),
-            text=name,
-            db=prefix,
-            id=identifier,
-            entry_name=name,
-            status="name",
-            source=prefix,
-        )
-
-    id_to_synonyms = get_id_synonyms_mapping(prefix, url=url)
-    for identifier, synonyms in tqdm(id_to_synonyms.items(), desc="mapping synonyms"):
-        name = id_to_name[identifier]
-        for synonym in synonyms:
-            yield gilda.term.Term(
-                norm_text=normalize(synonym),
-                text=synonym,
-                db=prefix,
-                id=identifier,
-                entry_name=name,
-                status="synonym",
-                source=prefix,
-            )

--- a/src/pyobo/apps/gilda/cli.py
+++ b/src/pyobo/apps/gilda/cli.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 @click.command(name="gilda")
-@click.argument("prefix")
+@click.argument("prefix", nargs=-1)
 @verbose_option
 @host_option
 @workers_option

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -20,7 +20,9 @@ __all__ = [
 ]
 
 
-def get_grounder(prefix: Union[str, Iterable[str]], unnamed: Optional[Iterable[str]] = None) -> Grounder:
+def get_grounder(
+    prefix: Union[str, Iterable[str]], unnamed: Optional[Iterable[str]] = None
+) -> Grounder:
     """Get a Gilda grounder for the given namespace."""
     unnamed = set() if unnamed is None else set(unnamed)
     if isinstance(prefix, str):
@@ -68,7 +70,7 @@ def get_gilda_terms(prefix: str, use_identifiers: bool = False) -> Iterable[gild
             )
 
     if use_identifiers:
-        for identifier in tqdm(get_ids(prefix), desc='mapping identifiers'):
+        for identifier in tqdm(get_ids(prefix), desc="mapping identifiers"):
             yield gilda.term.Term(
                 norm_text=normalize(identifier),
                 text=identifier,

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+"""PyOBO's Gilda utilities."""
+
+from typing import Iterable, Optional, Union
+
+import gilda.term
+from gilda.generate_terms import filter_out_duplicates
+from gilda.grounder import Grounder
+from gilda.process import normalize
+from tqdm import tqdm
+
+from pyobo import get_id_name_mapping, get_id_synonyms_mapping, get_ids
+from pyobo.getters import NoBuild
+from pyobo.utils.io import multidict
+
+__all__ = [
+    "get_grounder",
+    "get_gilda_terms",
+]
+
+
+def get_grounder(prefix: Union[str, Iterable[str]], unnamed: Optional[Iterable[str]] = None) -> Grounder:
+    """Get a Gilda grounder for the given namespace."""
+    unnamed = set() if unnamed is None else set(unnamed)
+    if isinstance(prefix, str):
+        prefix = [prefix]
+
+    terms = []
+    for p in prefix:
+        try:
+            p_terms = list(get_gilda_terms(p, use_identifiers=p in unnamed))
+        except NoBuild:
+            continue
+        else:
+            terms.extend(p_terms)
+    terms = filter_out_duplicates(terms)
+    terms = multidict((term.norm_text, term) for term in terms)
+    return Grounder(terms)
+
+
+def get_gilda_terms(prefix: str, use_identifiers: bool = False) -> Iterable[gilda.term.Term]:
+    """Get gilda terms for the given namespace."""
+    id_to_name = get_id_name_mapping(prefix)
+    for identifier, name in tqdm(id_to_name.items(), desc="mapping names"):
+        yield gilda.term.Term(
+            norm_text=normalize(name),
+            text=name,
+            db=prefix,
+            id=identifier,
+            entry_name=name,
+            status="name",
+            source=prefix,
+        )
+
+    id_to_synonyms = get_id_synonyms_mapping(prefix)
+    for identifier, synonyms in tqdm(id_to_synonyms.items(), desc="mapping synonyms"):
+        name = id_to_name[identifier]
+        for synonym in synonyms:
+            yield gilda.term.Term(
+                norm_text=normalize(synonym),
+                text=synonym,
+                db=prefix,
+                id=identifier,
+                entry_name=name,
+                status="synonym",
+                source=prefix,
+            )
+
+    if use_identifiers:
+        for identifier in tqdm(get_ids(prefix), desc='mapping identifiers'):
+            yield gilda.term.Term(
+                norm_text=normalize(identifier),
+                text=identifier,
+                db=prefix,
+                id=identifier,
+                entry_name=None,
+                status="identifier",
+                source=prefix,
+            )


### PR DESCRIPTION
This PR does the following:

1. Puts Gilda utilities in a top-level submodule instead of buried in the web app
2. Make it possible to make a gilda grounder with multiple prefixes
3. Enable using identifiers when generating gilda terms

Example run:

```bash
$ pyobo apps gilda -v efo clo cellosaurus depmap
```