### PR TITLE
Update version handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     cachier
     pystow>=0.2.3
     bioversions>=0.4.1
-    bioregistry>=0.4.0
+    bioregistry>=0.4.11
     drugbank_downloader
     chembl_downloader
     zenodo-client>=0.0.5

--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -33,7 +33,8 @@ def get_id_to_alts(prefix: str, force: bool = False) -> Mapping[str, List[str]]:
     if prefix in NO_ALTS:
         return {}
 
-    path = prefix_cache_join(prefix, name="alt_ids.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
     header = [f"{prefix}_id", "alt_id"]
 
     @cached_multidict(path=path, header=header, force=force)
@@ -42,7 +43,7 @@ def get_id_to_alts(prefix: str, force: bool = False) -> Mapping[str, List[str]]:
             logger.info(f"[{prefix}] forcing reload for alts")
         else:
             logger.info("[%s] no cached alts found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_id_alts_mapping()
 
     return _get_mapping()

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 @wrap_norm_prefix
 def get_metadata(prefix: str, force: bool = False) -> Mapping[str, str]:
     """Get metadata for the ontology."""
-    path = prefix_cache_join(prefix, name="metadata.json", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="metadata.json", version=version)
 
     @cached_json(path=path, force=force)
     def _get_json() -> Mapping[str, str]:
@@ -31,7 +32,7 @@ def get_metadata(prefix: str, force: bool = False) -> Mapping[str, str]:
             logger.info("[%s] forcing reload for metadata", prefix)
         else:
             logger.info("[%s] no cached metadata found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_metadata()
 
     return _get_json()

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -71,7 +71,8 @@ def get_ids(prefix: str, force: bool = False, strict: bool = True) -> Set[str]:
         logger.info("[%s] done loading name mappings", prefix)
         return rv
 
-    path = prefix_cache_join(prefix, name="ids.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="ids.tsv", version=version)
 
     @cached_collection(path=path, force=force)
     def _get_ids() -> Set[str]:
@@ -79,7 +80,7 @@ def get_ids(prefix: str, force: bool = False, strict: bool = True) -> Set[str]:
             logger.info("[%s] forcing reload for names", prefix)
         else:
             logger.info("[%s] no cached names found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_ids()
 
     return set(_get_ids())
@@ -97,7 +98,8 @@ def get_id_name_mapping(prefix: str, force: bool = False, strict: bool = True) -
         logger.info("[%s] done loading name mappings", prefix)
         return rv
 
-    path = prefix_cache_join(prefix, name="names.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="names.tsv", version=version)
 
     @cached_mapping(path=path, header=[f"{prefix}_id", "name"], force=force)
     def _get_id_name_mapping() -> Mapping[str, str]:
@@ -105,7 +107,7 @@ def get_id_name_mapping(prefix: str, force: bool = False, strict: bool = True) -
             logger.info("[%s] forcing reload for names", prefix)
         else:
             logger.info("[%s] no cached names found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_id_name_mapping()
 
     return _get_id_name_mapping()
@@ -127,12 +129,13 @@ def get_definition(prefix: str, identifier: str) -> Optional[str]:
 
 def get_id_definition_mapping(prefix: str, force: bool = False) -> Mapping[str, str]:
     """Get a mapping of descriptions."""
-    path = prefix_cache_join(prefix, name="definitions.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="definitions.tsv", version=version)
 
     @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force)
     def _get_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached descriptions found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_id_definition_mapping()
 
     return _get_mapping()
@@ -147,12 +150,13 @@ def get_synonyms(prefix: str, identifier: str) -> Optional[List[str]]:
 @wrap_norm_prefix
 def get_id_synonyms_mapping(prefix: str, force: bool = False) -> Mapping[str, List[str]]:
     """Get the OBO file and output a synonym dictionary."""
-    path = prefix_cache_join(prefix, name="synonyms.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="synonyms.tsv", version=version)
 
     @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force)
     def _get_multidict() -> Mapping[str, List[str]]:
         logger.info("[%s] no cached synonyms found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_id_synonyms_mapping()
 
     return _get_multidict()

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -129,7 +129,9 @@ def get_definition(prefix: str, identifier: str) -> Optional[str]:
     return _help_get(get_id_definition_mapping, prefix, identifier)
 
 
-def get_id_definition_mapping(prefix: str, force: bool = False) -> Mapping[str, str]:
+def get_id_definition_mapping(
+    prefix: str, force: bool = False, strict: bool = True
+) -> Mapping[str, str]:
     """Get a mapping of descriptions."""
     version = get_version(prefix)
     path = prefix_cache_join(prefix, name="definitions.tsv", version=version)
@@ -137,7 +139,7 @@ def get_id_definition_mapping(prefix: str, force: bool = False) -> Mapping[str, 
     @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force)
     def _get_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached descriptions found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_id_definition_mapping()
 
     return _get_mapping()
@@ -150,7 +152,9 @@ def get_synonyms(prefix: str, identifier: str) -> Optional[List[str]]:
 
 
 @wrap_norm_prefix
-def get_id_synonyms_mapping(prefix: str, force: bool = False) -> Mapping[str, List[str]]:
+def get_id_synonyms_mapping(
+    prefix: str, force: bool = False, strict: bool = True
+) -> Mapping[str, List[str]]:
     """Get the OBO file and output a synonym dictionary."""
     version = get_version(prefix)
     path = prefix_cache_join(prefix, name="synonyms.tsv", version=version)
@@ -158,7 +162,7 @@ def get_id_synonyms_mapping(prefix: str, force: bool = False) -> Mapping[str, Li
     @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force)
     def _get_multidict() -> Mapping[str, List[str]]:
         logger.info("[%s] no cached synonyms found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_id_synonyms_mapping()
 
     return _get_multidict()

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -35,7 +35,8 @@ def get_properties_df(prefix: str, *, force: bool = False) -> pd.DataFrame:
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe with the properties
     """
-    path = prefix_cache_join(prefix, name="properties.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
@@ -43,7 +44,7 @@ def get_properties_df(prefix: str, *, force: bool = False) -> pd.DataFrame:
             logger.info("[%s] forcing reload for properties", prefix)
         else:
             logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         df = ontology.get_properties_df()
         df.dropna(inplace=True)
         return df

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -68,10 +68,9 @@ def get_filtered_properties_mapping(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A mapping from identifier to property value
     """
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=get_version(prefix))
-    all_properties_path = prefix_cache_join(
-        prefix, name="properties.tsv", version=get_version(prefix)
-    )
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
     @cached_mapping(path=path, header=[f"{prefix}_id", prop], force=force)
     def _mapping_getter() -> Mapping[str, str]:
@@ -83,7 +82,7 @@ def get_filtered_properties_mapping(
             return dict(df.values)
 
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_filtered_properties_mapping(prop, use_tqdm=use_tqdm)
 
     return _mapping_getter()
@@ -105,10 +104,9 @@ def get_filtered_properties_multimapping(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A mapping from identifier to property values
     """
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=get_version(prefix))
-    all_properties_path = prefix_cache_join(
-        prefix, name="properties.tsv", version=get_version(prefix)
-    )
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
     @cached_multidict(path=path, header=[f"{prefix}_id", prop], force=force)
     def _mapping_getter() -> Mapping[str, List[str]]:
@@ -120,7 +118,7 @@ def get_filtered_properties_multimapping(
             return multidict(df.values)
 
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_filtered_properties_multimapping(prop, use_tqdm=use_tqdm)
 
     return _mapping_getter()
@@ -172,10 +170,9 @@ def get_filtered_properties_df(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe from identifier to property value. Columns are [<prefix>_id, value].
     """
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=get_version(prefix))
-    all_properties_path = prefix_cache_join(
-        prefix, name="properties.tsv", version=get_version(prefix)
-    )
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
@@ -189,7 +186,7 @@ def get_filtered_properties_df(
             logger.info("[%s] forcing reload for properties", prefix)
         else:
             logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_filtered_properties_df(prop, use_tqdm=use_tqdm)
 
     return _df_getter()

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -70,14 +70,15 @@ def get_filtered_relations_df(
 ) -> pd.DataFrame:
     """Get all of the given relation."""
     relation_prefix, relation_identifier = relation = get_reference_tuple(relation)
+    version = get_version(prefix)
     path = prefix_cache_join(
         prefix,
         "relations",
         name=f"{relation_prefix}:{relation_identifier}.tsv",
-        version=get_version(prefix),
+        version=version,
     )
     all_relations_path = prefix_cache_join(
-        prefix, name="relations.tsv", version=get_version(prefix)
+        prefix, name="relations.tsv", version=version
     )
 
     @cached_df(path=path, dtype=str, force=force)
@@ -92,7 +93,7 @@ def get_filtered_relations_df(
             return df.loc[idx, columns]
 
         logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_filtered_relations_df(relation, use_tqdm=use_tqdm)
 
     return _df_getter()

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -39,7 +39,8 @@ def get_relations_df(
     wide: bool = False,
 ) -> pd.DataFrame:
     """Get all relations from the OBO."""
-    path = prefix_cache_join(prefix, name="relations.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="relations.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
@@ -47,7 +48,7 @@ def get_relations_df(
             logger.info("[%s] forcing reload for relations", prefix)
         else:
             logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         return ontology.get_relations_df(use_tqdm=use_tqdm)
 
     rv = _df_getter()
@@ -77,9 +78,7 @@ def get_filtered_relations_df(
         name=f"{relation_prefix}:{relation_identifier}.tsv",
         version=version,
     )
-    all_relations_path = prefix_cache_join(
-        prefix, name="relations.tsv", version=version
-    )
+    all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
@@ -108,7 +107,8 @@ def get_id_multirelations_mapping(
     force: bool = False,
 ) -> Mapping[str, List[Reference]]:
     """Get the OBO file and output a synonym dictionary."""
-    ontology = get_ontology(prefix, force=force)
+    version = get_version(prefix)
+    ontology = get_ontology(prefix, force=force, version=version)
     return ontology.get_id_multirelations_mapping(typedef=typedef, use_tqdm=use_tqdm)
 
 
@@ -134,7 +134,8 @@ def get_relation_mapping(
     >>> hgnc_mgi_orthology_mapping = pyobo.get_relation_mapping('hgnc', 'ro:HOM0000017', 'mgi')
     >>> assert mouse_mapt_mgi_id == hgnc_mgi_orthology_mapping[human_mapt_hgnc_id]
     """
-    ontology = get_ontology(prefix, force=force)
+    version = get_version(prefix)
+    ontology = get_ontology(prefix, force=force, version=version)
     return ontology.get_relation_mapping(
         relation=relation, target_prefix=target_prefix, use_tqdm=use_tqdm
     )

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -55,12 +55,13 @@ def get_id_species_mapping(
         logger.info("[%s] done loading species mappings", prefix)
         return rv
 
-    path = prefix_cache_join(prefix, name="species.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="species.tsv", version=version)
 
     @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force)
     def _get_id_species_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached species found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         logger.info("[%s] loading species mappings", prefix)
         return ontology.get_id_species_mapping()
 

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -24,12 +24,13 @@ logger = logging.getLogger(__name__)
 @wrap_norm_prefix
 def get_typedef_df(prefix: str, force: bool = False) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
-    path = prefix_cache_join(prefix, name="typedefs.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
         logger.debug("[%s] no cached typedefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force)
+        ontology = get_ontology(prefix, force=force, version=version)
         logger.debug("[%s] loading typedef mappings", prefix)
         return ontology.get_typedef_df()
 

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -3,13 +3,15 @@
 """Utilities for high-level API."""
 
 import json
-import logging
 from typing import Optional
 
-from ..sources import has_nomenclature_plugin, run_nomenclature_plugin
+import bioversions
+
 from ..utils.path import prefix_directory_join
 
-logger = logging.getLogger(__name__)
+__all__ = [
+    "get_version",
+]
 
 
 def get_version(prefix: str) -> Optional[str]:
@@ -18,13 +20,14 @@ def get_version(prefix: str) -> Optional[str]:
     :param prefix: the resource name
     :return: The version if available else None
     """
-    if has_nomenclature_plugin(prefix):
-        return run_nomenclature_plugin(prefix).data_version
+    try:
+        version = bioversions.get_version(prefix)
+    except IOError:
+        raise IOError(f"[{prefix}] could not get version") from None
+    if version:
+        return version
 
     metadata_json_path = prefix_directory_join(prefix, name="metadata.json", ensure_exists=False)
     if metadata_json_path.exists():
-        with metadata_json_path.open() as file:
-            data = json.load(file)
-        rv = data["version"]
-        logger.debug("using pre-cached metadata version %s v%s", prefix, rv)
-        return rv
+        data = json.loads(metadata_json_path.read_text())
+        return data["version"]

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -45,9 +45,7 @@ def get_filtered_xrefs(
 ) -> Mapping[str, str]:
     """Get xrefs to a given target."""
     version = get_version(prefix)
-    path = prefix_cache_join(
-        prefix, "xrefs", name=f"{xref_prefix}.tsv", version=version
-    )
+    path = prefix_cache_join(prefix, "xrefs", name=f"{xref_prefix}.tsv", version=version)
     all_xrefs_path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
     header = [f"{prefix}_id", f"{xref_prefix}_id"]
 
@@ -75,12 +73,13 @@ def get_xrefs_df(
     prefix: str, *, use_tqdm: bool = False, force: bool = False, strict: bool = False
 ) -> pd.DataFrame:
     """Get all xrefs."""
-    path = prefix_cache_join(prefix, name="xrefs.tsv", version=get_version(prefix))
+    version = get_version(prefix)
+    path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force)
     def _df_getter() -> pd.DataFrame:
         logger.info("[%s] no cached xrefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_xrefs_df(use_tqdm=use_tqdm)
 
     return _df_getter()

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -44,10 +44,11 @@ def get_filtered_xrefs(
     strict: bool = False,
 ) -> Mapping[str, str]:
     """Get xrefs to a given target."""
+    version = get_version(prefix)
     path = prefix_cache_join(
-        prefix, "xrefs", name=f"{xref_prefix}.tsv", version=get_version(prefix)
+        prefix, "xrefs", name=f"{xref_prefix}.tsv", version=version
     )
-    all_xrefs_path = prefix_cache_join(prefix, name="xrefs.tsv", version=get_version(prefix))
+    all_xrefs_path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
     header = [f"{prefix}_id", f"{xref_prefix}_id"]
 
     @cached_mapping(path=path, header=header, use_tqdm=use_tqdm, force=force)
@@ -60,7 +61,7 @@ def get_filtered_xrefs(
             return dict(df.values)
 
         logger.info("[%s] no cached xrefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict)
+        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
         return ontology.get_filtered_xrefs_mapping(xref_prefix, use_tqdm=use_tqdm)
 
     rv = _get_mapping()

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -130,7 +130,7 @@ def get_ontology(
 
 
 def _ensure_ontology_path(
-    *, prefix: str, url: Optional[str] = None, force: bool = False, version: Optional[str] = None
+    prefix: str, *, url: Optional[str] = None, force: bool = False, version: Optional[str] = None
 ) -> pathlib.Path:
     """Get the path to the ontology file and download if missing."""
     if url is not None:

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -67,11 +67,12 @@ def get_ontology(
     """Get the OBO for a given graph.
 
     :param prefix: The prefix of the ontology to look up
+    :param version: The pre-looked-up version of the ontology
     :param force: Download the data again
     :param rewrite: Should the OBO cache be rewritten? Automatically set to true if ``force`` is true
     :param url: A URL to give if the OBOfoundry can not be used to look up the given prefix. This option is deprecated,
         you should make a PR to the bioregistry or use other code if you have a custom URL, like:
-    :param version: The pre-looked-up version of the ontology
+    :param strict: Should CURIEs be treated strictly? If true, raises exceptions on invalid/malformed
     :returns: An OBO object
 
     :raises OnlyOWLError: If the OBO foundry only has an OWL document for this resource.
@@ -115,7 +116,7 @@ def get_ontology(
         try:
             prontology = pronto.Ontology(path)
         except KeyError:
-            raise NoBuild(f"[{prefix}] could not parse OWL with pronto")
+            raise NoBuild(f"[{prefix}] could not parse OWL with pronto") from None
         version = prontology.metadata.data_version
         # prefix = prontology.metadata.ontology
         path = get_prefix_obo_path(prefix=prefix, version=version)
@@ -129,7 +130,7 @@ def get_ontology(
 
 
 def _ensure_ontology_path(
-    prefix: str, url: Optional[str] = None, force: bool = False, version: Optional[str] = None
+    *, prefix: str, url: Optional[str] = None, force: bool = False, version: Optional[str] = None
 ) -> pathlib.Path:
     """Get the path to the ontology file and download if missing."""
     if url is not None:

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -58,11 +58,11 @@ class UnhandledFormat(NoBuild):
 def get_ontology(
     prefix: str,
     *,
-    version: Optional[str],
     force: bool = False,
     rewrite: bool = False,
     url: Optional[str] = None,
     strict: bool = True,
+    version: Optional[str] = None,
 ) -> Obo:
     """Get the OBO for a given graph.
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -203,7 +203,7 @@ class TestGet(unittest.TestCase):
     def setUp(self) -> None:
         """Set up the test with the mock ChEBI OBO file."""
         with chebi_patch:
-            self.ontology = get_ontology("chebi", version=bioversions.get_version("chebi"))
+            self.ontology = get_ontology("chebi")
 
     def test_get_terms(self):
         """Test getting an OBO document."""

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -5,7 +5,6 @@
 import unittest
 from operator import attrgetter
 
-import bioversions
 import obonet
 
 from pyobo import Reference, Synonym, SynonymTypeDef, get_ontology

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -5,6 +5,7 @@
 import unittest
 from operator import attrgetter
 
+import bioversions
 import obonet
 
 from pyobo import Reference, Synonym, SynonymTypeDef, get_ontology
@@ -202,7 +203,7 @@ class TestGet(unittest.TestCase):
     def setUp(self) -> None:
         """Set up the test with the mock ChEBI OBO file."""
         with chebi_patch:
-            self.ontology = get_ontology("chebi")
+            self.ontology = get_ontology("chebi", version=bioversions.get_version("chebi"))
 
     def test_get_terms(self):
         """Test getting an OBO document."""


### PR DESCRIPTION
This PR improves the way that versions are looked up when getting resources. It doesn't expose these options on the top-level functions, though. It also better relies on `bioversions` for getting current version numbers