### PR TITLE
Use preferred prefixes when outputting OBO flat files

### DIFF
--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -196,6 +196,7 @@ def get_obsolete(
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="obsolete.tsv", version=version)
+
     @cached_collection(path=path, force=force)
     def _get_obsolete() -> Set[str]:
         ontology = get_ontology(prefix, force=force, strict=strict, version=version)

--- a/src/pyobo/sources/cgnc.py
+++ b/src/pyobo/sources/cgnc.py
@@ -8,6 +8,7 @@ from typing import Iterable
 import pandas as pd
 
 from pyobo.struct import Obo, Reference, Term, from_species
+from pyobo.struct.typedef import exact_match
 from pyobo.utils.path import ensure_df
 
 __all__ = [
@@ -25,7 +26,7 @@ class CGNCGetter(Obo):
 
     ontology = PREFIX
     dynamic_version = True
-    typedefs = [from_species]
+    typedefs = [from_species, exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/chembl.py
+++ b/src/pyobo/sources/chembl.py
@@ -12,7 +12,7 @@ from typing import Iterable
 import chembl_downloader
 
 from pyobo.struct import Obo, Reference, Term
-from pyobo.struct.typedef import has_inchi, has_smiles
+from pyobo.struct.typedef import exact_match, has_inchi, has_smiles
 
 __all__ = [
     "ChEMBLCompoundGetter",
@@ -45,6 +45,7 @@ class ChEMBLCompoundGetter(Obo):
 
     ontology = "chembl.compound"
     bioversions_key = "chembl"
+    typedefs = [exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/depmap.py
+++ b/src/pyobo/sources/depmap.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pystow
 
 from pyobo import Obo, Reference, Term
+from pyobo.struct.typedef import exact_match
 
 __all__ = [
     "get_obo",
@@ -23,6 +24,7 @@ class DepMapGetter(Obo):
 
     ontology = bioversions_key = PREFIX
     data_version = VERSION
+    typedefs = [exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/drugcentral.py
+++ b/src/pyobo/sources/drugcentral.py
@@ -12,7 +12,7 @@ import psycopg2
 from tqdm.auto import tqdm
 
 from pyobo.struct import Obo, Reference, Synonym, Term
-from pyobo.struct.typedef import has_inchi, has_smiles
+from pyobo.struct.typedef import exact_match, has_inchi, has_smiles
 
 __all__ = [
     "DrugCentralGetter",
@@ -34,6 +34,7 @@ class DrugCentralGetter(Obo):
     """An ontology representation of the DrugCentral database."""
 
     ontology = bioversions_key = PREFIX
+    typedefs = [exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/hgnc.py
+++ b/src/pyobo/sources/hgnc.py
@@ -27,6 +27,7 @@ from pyobo.struct import (
     orthologous,
     transcribes_to,
 )
+from pyobo.struct.typedef import exact_match
 from pyobo.utils.path import ensure_path, prefix_directory_join
 
 __all__ = [
@@ -212,6 +213,7 @@ class HGNCGetter(Obo):
         transcribes_to,
         orthologous,
         member_of,
+        exact_match,
     ]
     idspaces = IDSPACES
     synonym_typedefs = [

--- a/src/pyobo/sources/mgi.py
+++ b/src/pyobo/sources/mgi.py
@@ -9,6 +9,8 @@ from typing import Iterable
 import pandas as pd
 from tqdm.auto import tqdm
 
+from pyobo.struct.typedef import exact_match
+
 from ..struct import (
     Obo,
     Reference,
@@ -37,7 +39,7 @@ class MGIGetter(Obo):
 
     ontology = PREFIX
     dynamic_version = True
-    typedefs = [from_species, has_gene_product, transcribes_to]
+    typedefs = [from_species, has_gene_product, transcribes_to, exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/mirbase_family.py
+++ b/src/pyobo/sources/mirbase_family.py
@@ -40,7 +40,9 @@ def get_obo(force: bool = False) -> Obo:
 def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
     """Get miRBase family terms."""
     df = get_df(version, force=force)
-    for family_id, name, mirna_id, mirna_name in tqdm(df.values, total=len(df.index)):
+    for family_id, name, mirna_id, mirna_name in tqdm(
+        df.values, total=len(df.index), unit_scale=True, desc="miRBase Family"
+    ):
         term = Term(
             reference=Reference(prefix=PREFIX, identifier=family_id, name=name),
         )
@@ -65,4 +67,4 @@ def get_df(version: str, force: bool = False) -> pd.DataFrame:
 
 
 if __name__ == "__main__":
-    get_obo().write_default(use_tqdm=True)
+    get_obo().write_default(use_tqdm=True, write_obo=True, force=True)

--- a/src/pyobo/sources/npass.py
+++ b/src/pyobo/sources/npass.py
@@ -77,7 +77,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
                 logger.debug("multiple cids for %s: %s", identifier, pubchem_compound_ids)
             for pubchem_compound_id in pubchem_compound_ids:
                 term.append_xref(
-                    Reference(prefix="pubchem.compound", identifier=pubchem_compound_id)
+                    Reference(prefix="pubchem.compound", identifier=pubchem_compound_id.strip())
                 )
 
         for synonym in [iupac]:

--- a/src/pyobo/sources/ror.py
+++ b/src/pyobo/sources/ror.py
@@ -8,7 +8,8 @@ import bioregistry
 import zenodo_client
 from tqdm.auto import tqdm
 
-from pyobo.struct import Obo, Reference, SynonymTypeDef, Term, TypeDef
+from pyobo.struct import Obo, Reference, Term, TypeDef
+from pyobo.struct.struct import acronym
 
 PREFIX = "ror"
 ROR_ZENODO_RECORD_ID = "10086202"
@@ -20,8 +21,6 @@ PART_OF = Reference(prefix="BFO", identifier="0000050")
 HAS_PART = Reference(prefix="BFO", identifier="0000051")
 SUCCESSOR = Reference(prefix="BFO", identifier="0000063")
 PREDECESSOR = Reference(prefix="BFO", identifier="0000062")
-
-ACRONYM = SynonymTypeDef(reference=Reference(prefix="omo", identifier="0003000", name="acronym"))
 
 RMAP = {
     "Related": TypeDef.from_triple("rdfs", "seeAlso"),
@@ -45,7 +44,7 @@ class RORGetter(Obo):
 
     ontology = bioregistry_key = PREFIX
     typedefs = list(RMAP.values())
-    synonym_typedefs = [ACRONYM]
+    synonym_typedefs = [acronym]
     idspaces = {
         "ror": "https://ror.org/",
         "geonames": "https://www.geonames.org/",
@@ -110,8 +109,8 @@ def iterate_ror_terms(*, force: bool = False) -> Iterable[Term]:
             if synonym.startswith("The "):
                 term.append_synonym(synonym.removeprefix("The "))
 
-        for acronym in record.get("acronyms", []):
-            term.append_synonym(acronym, type=ACRONYM)
+        for acronym_synonym in record.get("acronyms", []):
+            term.append_synonym(acronym_synonym, type=acronym)
 
         for prefix, xref_data in record.get("external_ids", {}).items():
             if prefix == "OrgRef":

--- a/src/pyobo/sources/sgd.py
+++ b/src/pyobo/sources/sgd.py
@@ -5,7 +5,7 @@
 from typing import Iterable
 from urllib.parse import unquote_plus
 
-from ..struct import Obo, Reference, Synonym, SynonymTypeDef, Term, from_species
+from ..struct import Obo, Reference, Synonym, Term, from_species
 from ..utils.path import ensure_tar_df
 
 __all__ = [
@@ -21,15 +21,12 @@ URL = (
 )
 INNER_PATH = "S288C_reference_genome_R64-2-1_20150113/saccharomyces_cerevisiae_R64-2-1_20150113.gff"
 
-alias_type = SynonymTypeDef.from_text("alias")
-
 
 class SGDGetter(Obo):
     """An ontology representation of SGD's yeast gene nomenclature."""
 
     bioversions_key = ontology = PREFIX
     typedefs = [from_species]
-    synonym_typedefs = [alias_type]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms for SGD."""
@@ -68,7 +65,7 @@ def get_terms(ontology: Obo, force: bool = False) -> Iterable[Term]:
         aliases = d.get("Alias")
         if aliases:
             for alias in aliases.split(","):
-                synonyms.append(Synonym(name=unquote_plus(alias), type=alias_type))
+                synonyms.append(Synonym(name=unquote_plus(alias)))
 
         term = Term(
             reference=Reference(prefix=PREFIX, identifier=identifier, name=name),

--- a/src/pyobo/sources/slm.py
+++ b/src/pyobo/sources/slm.py
@@ -7,8 +7,9 @@ from typing import Iterable
 import pandas as pd
 from tqdm.auto import tqdm
 
-from pyobo import Obo, Reference, SynonymTypeDef, Term
-from pyobo.struct.typedef import has_inchi, has_smiles
+from pyobo import Obo, Reference, Term
+from pyobo.struct.struct import abbreviation as abbreviation_typedef
+from pyobo.struct.typedef import exact_match, has_inchi, has_smiles
 from pyobo.utils.path import ensure_df
 
 __all__ = [
@@ -38,14 +39,13 @@ COLUMNS = [
     "PMID",
 ]
 
-abreviation_type = SynonymTypeDef.from_text("abbreviation")
-
 
 class SLMGetter(Obo):
     """An ontology representation of SwissLipid's lipid nomenclature."""
 
     ontology = bioversions_key = PREFIX
-    synonym_typedefs = [abreviation_type]
+    typedefs = [exact_match]
+    synonym_typedefs = [abbreviation_typedef]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""
@@ -94,7 +94,7 @@ def iter_terms(version: str, force: bool = False):
         if pd.notna(level):
             term.append_property("level", level)
         if pd.notna(abbreviation):
-            term.append_synonym(abbreviation, type=abreviation_type)
+            term.append_synonym(abbreviation, type=abbreviation_typedef)
         if pd.notna(synonyms):
             for synonym in synonyms.split("|"):
                 term.append_synonym(synonym.strip())

--- a/src/pyobo/sources/zfin.py
+++ b/src/pyobo/sources/zfin.py
@@ -16,6 +16,7 @@ from pyobo.struct import (
     has_gene_product,
     orthologous,
 )
+from pyobo.struct.typedef import exact_match
 from pyobo.utils.io import multidict, multisetdict
 from pyobo.utils.path import ensure_df
 
@@ -40,7 +41,7 @@ class ZFINGetter(Obo):
     """An ontology representation of ZFIN's zebrafish database."""
 
     bioversions_key = ontology = PREFIX
-    typedefs = [from_species, has_gene_product, orthologous]
+    typedefs = [from_species, has_gene_product, orthologous, exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in ZFIN."""

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -31,6 +31,12 @@ class Reference(curies.Reference):
             raise ExpansionError(f"Unknown prefix: {v}")
         return norm_prefix
 
+    @property
+    def preferred_curie(self) -> str:
+        """Get the preferred curie for this reference."""
+        pp = bioregistry.get_preferred_prefix(self.prefix) or self.prefix
+        return f"{pp}:{self.identifier}"
+
     @root_validator(pre=True)
     def validate_identifier(cls, values):  # noqa
         """Validate the identifier."""
@@ -152,6 +158,11 @@ class Referenced:
     def curie(self) -> str:
         """The CURIE for this typedef."""  # noqa: D401
         return self.reference.curie
+
+    @property
+    def preferred_curie(self) -> str:
+        """The preferred CURIE for this typedef."""  # noqa: D401
+        return self.reference.preferred_curie
 
     @property
     def pair(self) -> Tuple[str, str]:

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -47,6 +47,7 @@ from .typedef import (
     exact_match,
     from_species,
     get_reference_tuple,
+    has_ontology_root_term,
     has_part,
     is_a,
     orthologous,
@@ -108,7 +109,7 @@ class Synonym:
     def _fp(self) -> str:
         x = f'"{self._escape(self.name)}" {self.specificity}'
         if self.type and self.type.pair != DEFAULT_SYNONYM_TYPE.pair:
-            x = f"{x} {self.type.curie}"
+            x = f"{x} {self.type.preferred_curie}"
         return f"{x} [{comma_separate(self.provenance)}]"
 
     @staticmethod
@@ -125,7 +126,7 @@ class SynonymTypeDef(Referenced):
 
     def to_obo(self) -> str:
         """Serialize to OBO."""
-        rv = f'synonymtypedef: {self.curie} "{self.name}"'
+        rv = f'synonymtypedef: {self.preferred_curie} "{self.name}"'
         if self.specificity:
             rv = f"{rv} {self.specificity}"
         return rv
@@ -399,10 +400,10 @@ class Term(Referenced):
             for value in values:
                 yield prop, value
 
-    def iterate_obo_lines(self) -> Iterable[str]:
+    def iterate_obo_lines(self, *, ontology, typedefs) -> Iterable[str]:
         """Iterate over the lines to write in an OBO file."""
         yield f"\n[{self.type}]"
-        yield f"id: {self.curie}"
+        yield f"id: {self.preferred_curie}"
         if self.is_obsolete:
             yield "is_obsolete: true"
         if self.name:
@@ -417,15 +418,18 @@ class Term(Referenced):
             yield f"def: {self._definition_fp()}"
 
         for xref in sorted(self.xrefs, key=attrgetter("prefix", "identifier")):
-            yield f"xref: {xref}"
+            yield f"xref: {xref.preferred_curie}"
 
         parent_tag = "is_a" if self.type == "Term" else "instance_of"
         for parent in sorted(self.parents, key=attrgetter("prefix", "identifier")):
             yield f"{parent_tag}: {parent}"
 
         for typedef, references in sorted(self.relationships.items(), key=_sort_relations):
+            if typedef not in typedefs:
+                logger.warning(f"[{ontology}] typedef not defined in OBO: {typedef}")
+            typedef_preferred_curie = typedef.preferred_curie
             for reference in sorted(references, key=attrgetter("prefix", "identifier")):
-                s = f"relationship: {typedef.curie} {reference.curie}"
+                s = f"relationship: {typedef_preferred_curie} {reference.preferred_curie}"
                 if typedef.name or reference.name:
                     s += " !"
                 if typedef.name:
@@ -435,6 +439,7 @@ class Term(Referenced):
                 yield s
 
         for prop, value in sorted(self.iterate_properties(), key=_sort_properties):
+            # TODO deal with typedefs for properties
             yield f'property_value: {prop} "{value}" xsd:string'  # TODO deal with types later
 
         for synonym in sorted(self.synonyms, key=attrgetter("name")):
@@ -654,15 +659,22 @@ class Obo:
         if self.name is None:
             raise ValueError("ontology is missing name")
         yield f'property_value: http://purl.org/dc/elements/1.1/title "{self.name}" xsd:string'
+        license_spdx_id = bioregistry.get_license(self.ontology)
+        if license_spdx_id:
+            # TODO add SPDX to idspaces and use as a CURIE?
+            yield f'property_value: http://purl.org/dc/terms/license "{license_spdx_id}" xsd:string'
+        description = bioregistry.get_description(self.ontology)
+        if description:
+            yield f'property_value: http://purl.org/dc/elements/1.1/description "{description}" xsd:string'
 
         for root_term in self.root_terms or []:
-            yield f"property_value: IAO:0000700 {root_term.curie}"
+            yield f"property_value: {has_ontology_root_term.preferred_curie} {root_term.preferred_curie}"
 
         for typedef in sorted(self.typedefs or [], key=attrgetter("curie")):
             yield from typedef.iterate_obo_lines()
 
         for term in self:
-            yield from term.iterate_obo_lines()
+            yield from term.iterate_obo_lines(ontology=self.ontology, typedefs=self.typedefs)
 
     def write_obo(
         self, file: Union[None, str, TextIO, Path] = None, use_tqdm: bool = False

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -75,7 +75,7 @@ class TypeDef(Referenced):
     def iterate_obo_lines(self) -> Iterable[str]:
         """Iterate over the lines to write in an OBO file."""
         yield "\n[Typedef]"
-        yield f"id: {self.reference.curie}"
+        yield f"id: {self.reference.preferred_curie}"
         if self.name:
             yield f"name: {self.reference.name}"
         if self.definition:
@@ -94,7 +94,7 @@ class TypeDef(Referenced):
             yield f"comment: {self.comment}"
 
         for xref in self.xrefs:
-            yield f"xref: {xref}"
+            yield f"xref: {xref.preferred_curie}"
 
         if self.is_transitive is not None:
             yield f'is_transitive: {"true" if self.is_transitive else "false"}'
@@ -102,7 +102,7 @@ class TypeDef(Referenced):
         if self.is_symmetric is not None:
             yield f'is_symmetric: {"true" if self.is_symmetric else "false"}'
         if self.holds_over_chain:
-            _chain = " ".join(link.curie for link in self.holds_over_chain)
+            _chain = " ".join(link.preferred_curie for link in self.holds_over_chain)
             _names = " / ".join(link.name or "_" for link in self.holds_over_chain)
             yield f"holds_over_chain: {_chain} ! {_names}"
 
@@ -263,6 +263,10 @@ has_salt = TypeDef(
 
 example_of_usage = Reference(prefix=IAO_PREFIX, identifier="0000112", name="example of usage")
 alternative_term = Reference(prefix=IAO_PREFIX, identifier="0000118", name="alternative term")
+has_ontology_root_term = TypeDef.from_triple(
+    prefix=IAO_PREFIX, identifier="0000700", name="has ontology root term"
+)
+
 editor_note = Reference(prefix=IAO_PREFIX, identifier="0000116", name="editor note")
 
 is_immediately_transformed_from = TypeDef.from_triple(

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -40,6 +40,9 @@ __all__ = [
     "enables",
     "participates_in",
     "has_participant",
+    "exact_match",
+    "has_dbxref",
+    # Properties
     "has_inchi",
     "has_smiles",
 ]
@@ -266,6 +269,7 @@ alternative_term = Reference(prefix=IAO_PREFIX, identifier="0000118", name="alte
 has_ontology_root_term = TypeDef.from_triple(
     prefix=IAO_PREFIX, identifier="0000700", name="has ontology root term"
 )
+has_dbxref = TypeDef.from_curie("oboInOwl:hasDbXref", name="has database cross-reference")
 
 editor_note = Reference(prefix=IAO_PREFIX, identifier="0000116", name="editor note")
 


### PR DESCRIPTION
Closes #161 
Closes https://github.com/biopragmatics/obo-db-ingest/issues/6

This will ensure that the obo-db-ingest documents can be more readily merged with other OBO Foundry ontologies

This PR also sprinkles in descriptions and licenses when outputting OBO